### PR TITLE
Use a pseudo-tty to execute operations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ Release History
 Unreleased
 ++++++++++
 
+**Improvements**
+
+- New dependency on ``pexpect``. Used to create a pseudo-tty to execute the
+  operations.  It enables line buffering and interactivity for pdb in the
+  children processes.
+
 
 0.3.3 (2016-07-12)
 ++++++++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setup(
     license='AGPLv3+',
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=["psycopg2",
-                      "PyYAML"],
+                      "PyYAML",
+                      "pexpect",
+                      ],
     classifiers=(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 
+# flake8: noqa
+# we want to ignore:
+# F401 'marabunta' imported but unused
+# E402 module level import not at top of file
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))


### PR DESCRIPTION
Using 'pexpect'.  It enables line buffering and interactivity for pdb in
the children processes.