### PR TITLE
Disable interactive mode when stdout is not a tty

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,9 @@ Unreleased
 
 **Bugfixes**
 
+- Prevent error (25, 'Inappropriate ioctl for device') when
+  stdout is not a tty by disabling the interactive mode.
+
 **Improvements**
 
 **Documentation**

--- a/marabunta/runner.py
+++ b/marabunta/runner.py
@@ -97,18 +97,18 @@ class VersionRunner(object):
         self.version = version
         self.logs = []
 
-    def log(self, message, raw=False, stdout=True):
-        self.logs.append(message.strip() if raw else message)
+    def log(self, message, decorated=True, stdout=True):
+        self.logs.append(message)
         if not stdout:
             return
-        if raw:
-            safe_print(message, end=u'')
-        else:
+        if decorated:
             app_message = u'version {}: {}'.format(
                 self.version.number,
                 message,
             )
             print_decorated(app_message)
+        else:
+            safe_print(message)
 
     def start(self):
         self.log(u'start')


### PR DESCRIPTION
As mentioned in #5, if stdout is not a tty, we got the following error:

termios.error: (25, 'Inappropriate ioctl for device')

The correction is to degrade to a non-interactive mode when we don't
have a tty, which is detected with 'sys.stdout.isatty()' as proposed by
@lepistone.