### PR TITLE
Use 'odoo' as default install command

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Unreleased
 
 **Features**
 
+- Switch the default command line for running odoo to ``odoo`` instead of
+  ``odoo.py`` (renamed in Odoo 10). For usage with previous version, you must
+  specify the ``install_command`` in the ``migration.yml`` file.
+
 **Bugfixes**
 
 **Improvements**

--- a/marabunta/model.py
+++ b/marabunta/model.py
@@ -30,7 +30,7 @@ class Migration(object):
 class MigrationOption(object):
 
     def __init__(self, install_command=None, install_args=None):
-        self.install_command = install_command or u'odoo.py'
+        self.install_command = install_command or u'odoo'
         self.install_args = install_args or u''
 
 


### PR DESCRIPTION
For Odoo version < 10.0, the install_command option in the migration
file should be specified.