### PR TITLE
Lock migration with an advisory lock

### DIFF
--- a/marabunta/database.py
+++ b/marabunta/database.py
@@ -60,22 +60,6 @@ class MigrationTable(object):
         """.format(self.table_name)
         self.cursor.execute(query)
 
-    def lock(self):
-        """ Lock the entire migration table
-
-        The lock is released the next commit or rollback.
-        The purpose is to prevent 2 processes to execute the same migration at
-        the same time.
-
-        The other transaction should because if they exit, whey will either be
-        dead, either run Odoo and we want neither of them.
-
-        """
-        query = """
-        LOCK TABLE {}
-        """.format(self.table_name)
-        self.cursor.execute(query)
-
     def versions(self):
         """ Read versions from the table
 

--- a/marabunta/runner.py
+++ b/marabunta/runner.py
@@ -30,7 +30,6 @@ class Runner(object):
 
     def perform(self):
         self.table.create_if_not_exists()
-        self.table.lock()  # locked until end of transaction
 
         db_versions = self.table.versions()
 


### PR DESCRIPTION
Prevent 2 processes to run the migration at the same time.