### PR TITLE
Rework database connection handling

### DIFF
--- a/marabunta/runner.py
+++ b/marabunta/runner.py
@@ -14,10 +14,10 @@ LOG_DECORATION = u'|> '
 
 class Runner(object):
 
-    def __init__(self, config, migration, cursor, table):
+    def __init__(self, config, migration, connection, table):
         self.config = config
         self.migration = migration
-        self.cursor = cursor
+        self.connection = connection
         self.table = table
         # we keep the addons upgrading during a run in this set,
         # this is only useful when using 'allow_serie',
@@ -92,7 +92,7 @@ class VersionRunner(object):
         self.table = runner.table
         self.migration = runner.migration
         self.config = runner.config
-        self.cursor = runner.cursor
+        self.connection = runner.connection
         self.version = version
         self.logs = []
 
@@ -115,7 +115,7 @@ class VersionRunner(object):
 
     def finish(self):
         self.log(u'done')
-        module_table = IrModuleModule(self.cursor)
+        module_table = IrModuleModule(self.connection)
         addons_state = module_table.read_state()
         self.table.finish_version(self.version.number, datetime.now(),
                                   u'\n'.join(self.logs),
@@ -161,7 +161,7 @@ class VersionRunner(object):
     def perform_addons(self):
         version = self.version
 
-        module_table = IrModuleModule(self.cursor)
+        module_table = IrModuleModule(self.connection)
         addons_state = module_table.read_state()
 
         upgrade_operation = version.upgrade_addons_operation(


### PR DESCRIPTION
* The advisory lock is opened in a cursor in a thread,
  this cursor periodically executes a dummy 'SELECT 1' to be sure that the
  connection stay alive (not killed with a timeout) when a long-running
  subprocess is run
* The operations in database are executed in short-lived cursors. This
  prevents an issue we had when the open cursor was locking
  'ir_module_module', preventing odoo to install/update properly.
  Anyway, we were committing the cursor in all cases.

Fixes #11 