### PR TITLE
Autocommit the changes done in 'marabunta_version'

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,13 @@ Unreleased
 
 **Bugfixes**
 
+* Autocommit the operations done in the marabunta_version table.  Previously,
+  after an exception, the changes to marabunta_version were rollbacked, which
+  is not the expected behavior (it makes the migration restart ceaseless).
+  As a side effect, Marabunta now opens 2 connections. The connection opened
+  for the adsivory lock cannot commit before the end because it would release
+  the lock.
+
 **Improvements**
 
 **Documentation**

--- a/marabunta/database.py
+++ b/marabunta/database.py
@@ -29,8 +29,10 @@ class Database(object):
         return '%s %s %s %s %s' % (host, port, name, user, password)
 
     @contextmanager
-    def connect(self):
+    def connect(self, autocommit=False):
         with psycopg2.connect(self.dsn()) as conn:
+            if autocommit:
+                conn.autocommit = True
             yield conn
 
 


### PR DESCRIPTION
Autocommit the operations done in the marabunta_version table.  Previously,
after an exception, the changes to marabunta_version were rollbacked, which
is not the expected behavior (it makes the migration restart ceaseless).
As a side effect, Marabunta now opens 2 connections. The connection opened
for the adsivory lock cannot commit before the end because it would release
the lock.