### PR TITLE
Publish maintenance page during migration

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Unreleased
 
 **Features**
 
+* Publish a maintenance web page during migration. The host and port are
+  configurable with new options. By default the port match odoo's (8069). A
+  default maintenance is provided, but it can be configured as well.
+
 **Bugfixes**
 
 **Improvements**

--- a/marabunta/config.py
+++ b/marabunta/config.py
@@ -17,7 +17,10 @@ class Config(object):
                  db_host='localhost',
                  mode=None,
                  allow_serie=False,
-                 force_version=None):
+                 force_version=None,
+                 web_host='localhost',
+                 web_port=8069,
+                 web_custom_html=None):
         self.migration_file = migration_file
         self.database = database
         self.db_user = db_user
@@ -29,6 +32,9 @@ class Config(object):
         self.force_version = force_version
         if force_version and not allow_serie:
             self.allow_serie = True
+        self.web_host = web_host
+        self.web_port = web_port
+        self.web_custom_html = web_custom_html
 
     @classmethod
     def from_parse_args(cls, args):
@@ -48,6 +54,9 @@ class Config(object):
                    mode=args.mode,
                    allow_serie=args.allow_serie,
                    force_version=args.force_version,
+                   web_host=args.web_host,
+                   web_port=args.web_port,
+                   web_custom_html=args.web_custom_html,
                    )
 
 
@@ -117,4 +126,24 @@ def get_args_parser():
                         default=os.environ.get('MARABUNTA_FORCE_VERSION'),
                         help='Force upgrade of a version, even if it has '
                              'already been applied.')
+
+    group = parser.add_argument_group(
+        title='Web',
+        description='Configuration related to the internal web server, '
+                    'used to publish a maintenance page during the migration.',
+    )
+    group.add_argument('--web-host',
+                       required=False,
+                       default=os.environ.get('MARABUNTA_WEB_HOST', '0.0.0.0'),
+                       help='Host for the web server')
+    group.add_argument('--web-port',
+                       required=False,
+                       default=os.environ.get('MARABUNTA_WEB_PORT', 8069),
+                       help='Port for the web server')
+    group.add_argument('--web-custom-html',
+                       required=False,
+                       default=os.environ.get(
+                           'MARABUNTA_WEB_CUSTOM_HTML'
+                       ),
+                       help='Path to a custom html file to publish')
     return parser

--- a/marabunta/html/migration.html
+++ b/marabunta/html/migration.html
@@ -1,0 +1,118 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>odoo maintenance</title>
+  <meta name="viewport" content="width=device-width">
+  <meta http-equiv="refresh" content="10" />
+  <style>
+    html {
+      font-family: sans-serif;
+      line-height: 1.15;
+      -webkit-text-size-adjust: 100%;
+    }
+    body {
+      color: #fff;
+      background-color: #21232a;
+      text-align: center;
+      text-shadow: 0 2px 4px rgba(0,0,0,.5);
+      -webkit-box-shadow: inset 0 0 75pt rgba(0,0,0,.8);
+      box-shadow: inset 0 0 75pt rgba(0,0,0,.8);
+      font-family: "Open Sans",Arial,sans-serif;
+      margin: 0;
+      padding: 0;
+      min-height: 100%;
+      display: table;
+      width: 100%;
+      height: 100%;
+    }
+    .cover {
+      display: table-cell;
+      vertical-align: middle;
+      padding: 0 20px;
+    }
+    h1 {
+      margin: .67em 0;
+      font-family: inherit;
+      font-weight: 500;
+      line-height: 1.1;
+      color: inherit;
+      font-size: 36px;
+
+    }
+    .message {
+      color: silver;
+      font-size: 21px;
+      line-height: 1.4;
+    }
+
+    /* loader from https://projects.lukehaas.me/css-loaders/ */
+    .loader,
+    .loader:before,
+    .loader:after {
+      background: #a24689;
+      -webkit-animation: load1 1s infinite ease-in-out;
+      animation: load1 1s infinite ease-in-out;
+      width: 1em;
+      height: 4em;
+    }
+    .loader {
+      color: #a24689;
+      text-indent: -9999em;
+      margin: 88px auto;
+      position: relative;
+      font-size: 11px;
+      -webkit-transform: translateZ(0);
+      -ms-transform: translateZ(0);
+      transform: translateZ(0);
+      -webkit-animation-delay: -0.16s;
+      animation-delay: -0.16s;
+    }
+    .loader:before,
+    .loader:after {
+      position: absolute;
+      top: 0;
+      content: '';
+    }
+    .loader:before {
+      left: -1.5em;
+      -webkit-animation-delay: -0.32s;
+      animation-delay: -0.32s;
+    }
+    .loader:after {
+      left: 1.5em;
+    }
+    @-webkit-keyframes load1 {
+      0%,
+      80%,
+      100% {
+        box-shadow: 0 0;
+        height: 4em;
+      }
+      40% {
+        box-shadow: 0 -2em;
+        height: 5em;
+      }
+    }
+    @keyframes load1 {
+      0%,
+      80%,
+      100% {
+        box-shadow: 0 0;
+        height: 4em;
+      }
+      40% {
+        box-shadow: 0 -2em;
+        height: 5em;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="cover">
+    <div class="loader">Waiting...</div>
+    <h1>odoo maintenance</h1>
+    <p class="message">An upgrade of the application is currently in progress... please come back later.</p>
+  </div>
+</body>
+</html>

--- a/marabunta/web.py
+++ b/marabunta/web.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import os
+
+from werkzeug.wrappers import Request, Response
+from werkzeug.serving import run_simple
+
+
+class WebApp(object):
+
+    def __init__(self, host, port, custom_maintenance_file=None):
+        self.host = host
+        self.port = port
+        if not custom_maintenance_file:
+            custom_maintenance_file = os.path.join(
+                os.path.dirname(__file__),
+                'html/migration.html'
+            )
+        with open(custom_maintenance_file, 'r') as f:
+            self.maintenance_html = f.read()
+
+    def serve(self):
+        run_simple(self.host, self.port, self)
+
+    def dispatch_request(self, request):
+        return Response(self.maintenance_html, mimetype='text/html')
+
+    def wsgi_app(self, environ, start_response):
+        request = Request(environ)
+        response = self.dispatch_request(request)
+        return response(environ, start_response)
+
+    def __call__(self, environ, start_response):
+        return self.wsgi_app(environ, start_response)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     install_requires=["psycopg2",
                       "PyYAML",
                       "pexpect",
+                      "werkzeug",
                       ],
     classifiers=(
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
I create this PR to track my progress.

* [x] webserver is started and publish on localhost:8069
* [x] pretty migration page (I hope)
* [x] add options for webapp host & port
* [x] clean my previous tests with rendering of logs
* [ ] JavaScript mini games ;-)

Migration page example: http://htmlpreview.github.io/?https://raw.githubusercontent.com/guewen/marabunta/3e2301a23478595823a140af15236ce3b1dab288/marabunta/html/migration.html