### PR TITLE
Change name of a method for less confusion

### DIFF
--- a/marabunta/database.py
+++ b/marabunta/database.py
@@ -36,7 +36,7 @@ class Database(object):
             yield conn
 
     @contextmanager
-    def cursor(self, autocommit=False):
+    def cursor_autocommit(self):
         with self.connect(autocommit=True) as conn:
             with conn.cursor() as cursor:
                 yield cursor
@@ -54,7 +54,7 @@ class MigrationTable(object):
         self._versions = None
 
     def create_if_not_exists(self):
-        with self.database.cursor() as cursor:
+        with self.database.cursor_autocommit() as cursor:
             query = """
             CREATE TABLE IF NOT EXISTS {} (
                 number VARCHAR NOT NULL,
@@ -74,7 +74,7 @@ class MigrationTable(object):
         The versions are kept in cache for the next reads.
         """
         if self._versions is None:
-            with self.database.cursor() as cursor:
+            with self.database.cursor_autocommit() as cursor:
                 query = """
                 SELECT number,
                        date_start,
@@ -97,7 +97,7 @@ class MigrationTable(object):
         return self._versions
 
     def start_version(self, number, start):
-        with self.database.cursor() as cursor:
+        with self.database.cursor_autocommit() as cursor:
             query = """
             SELECT number FROM {}
             WHERE number = %s
@@ -123,7 +123,7 @@ class MigrationTable(object):
         self._versions = None  # reset versions cache
 
     def finish_version(self, number, end, log, addons):
-        with self.database.cursor() as cursor:
+        with self.database.cursor_autocommit() as cursor:
             query = """
             UPDATE {}
             SET date_done = %s,
@@ -146,7 +146,7 @@ class IrModuleModule(object):
         )
 
     def read_state(self):
-        with self.database.cursor() as cursor:
+        with self.database.cursor_autocommit() as cursor:
             if not table_exists(cursor, self.table_name):
                 # relation ir_module_module does not exists,
                 # this is a new DB, no addon is installed


### PR DESCRIPTION
The cursor method was using an 'autocommit' argument which was not used
and forced below. Besides, the 'Database.cursor()' method could be
confused with 'Database.connection().cursor()' although they don't do
the same thing. 'Database.cursor_autocommit' will be more readable.