### PR TITLE
Fix error with unicode commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,10 +78,9 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 
-# dotenv
-.env
-
 # virtualenv
+.env
+.env3
 venv/
 ENV/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: python
 
 env:
   - TOXENV=py27
-  - TOXENV=py34
 
 matrix:
   include:
-  - python: 3.5
-    env: TOXENV=py35
-  - python: 3.5
+  - python: 2.7
+    env: TOXENV=py27
+  - python: 2.7
     env: TOXENV=lint
 
 before_script:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,9 @@ Unreleased
 
 **Build**
 
+* Removed python3 from tox, it doesn't run on py3 and we can't make them run
+  now. Odoo is still python2, py3 compat will come when it'll switch.
+
 
 0.6.3 (2016-12-12)
 ++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ Unreleased
 
 **Bugfixes**
 
+* Commands with unicode chars make the migration fail
+
 **Improvements**
 
 **Documentation**

--- a/marabunta/model.py
+++ b/marabunta/model.py
@@ -203,15 +203,19 @@ class Operation(object):
 
     def __init__(self, command):
         if isinstance(command, string_types):
-            command = shlex.split(command)
+            command = self._shlex_split_unicode(command)
         self.command = command
+
+    @staticmethod
+    def _shlex_split_unicode(command):
+        return [l.decode('utf8') for l in shlex.split(command.encode('utf8'))]
 
     def __nonzero__(self):
         return bool(self.command)
 
     def _execute(self, log, interactive=True):
-        child = pexpect.spawn(self.command[0],
-                              self.command[1:],
+        child = pexpect.spawn(self.command[0].encode('utf8'),
+                              [l.encode('utf8') for l in self.command[1:]],
                               timeout=None,
                               )
         # interact() will transfer the child's stdout to

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,lint
+envlist = py27,lint
 
 [testenv]
 deps =
@@ -7,7 +7,7 @@ deps =
 commands = py.test {posargs}
 
 [testenv:lint]
-basepython = python3.5
+basepython = python2.7
 deps =
     flake8
     readme_renderer


### PR DESCRIPTION
shlex.split wraps unicode() and str() strings in a StringIO object which
only support Latin-1 bytes encode to utf8 to allow usage of unicode in
commands.

Same fix with pexpect.spawn which expects bytes.