### PR TITLE
[IMP] update psycop dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url='https://github.com/camptocamp/marabunta',
     license='AGPLv3+',
     packages=find_packages(exclude=('tests', 'docs')),
-    install_requires=["psycopg2",
+    install_requires=["psycopg2-binary",
                       "PyYAML",
                       "pexpect",
                       "werkzeug",


### PR DESCRIPTION
```bash
/tmp/marabunta/marabunta/env/local/lib/python2.7/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```