### PR TITLE
Marabunta first version as "setup"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/marabunta/model.py
+++ b/marabunta/model.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2017 Camptocamp SA
+# Copyright 2016-2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import shlex
 import sys
 
 from builtins import object
-from distutils.version import StrictVersion
 from io import StringIO
 
 import pexpect
 
 from .exception import ConfigurationError, OperationError
 from .helpers import string_types
+from .version import MarabuntaVersion
 
 
 class Migration(object):
@@ -22,7 +22,7 @@ class Migration(object):
 
     @property
     def versions(self):
-        return sorted(self._versions, key=lambda v: StrictVersion(v.number))
+        return sorted(self._versions, key=lambda v: MarabuntaVersion(v.number))
 
 
 class MigrationOption(object):
@@ -36,7 +36,7 @@ class Version(object):
 
     def __init__(self, number, options):
         try:
-            StrictVersion().parse(number)
+            MarabuntaVersion().parse(number)
         except ValueError:
             raise ConfigurationError(
                 u'{} is not a valid version'.format(number)

--- a/marabunta/runner.py
+++ b/marabunta/runner.py
@@ -6,11 +6,11 @@ import traceback
 import sys
 
 from datetime import datetime
-from distutils.version import StrictVersion
 
 from .database import IrModuleModule
 from .exception import MigrationError
 from .output import print_decorated, safe_print
+from .version import MarabuntaVersion
 
 LOG_DECORATION = u'|> '
 
@@ -64,8 +64,10 @@ class Runner(object):
                 )
 
         if not self.config.force_version and db_versions and unprocessed:
-            installed = max(StrictVersion(v.number) for v in db_versions)
-            next_unprocess = min(StrictVersion(v.number) for v in unprocessed)
+            installed = max(MarabuntaVersion(v.number) for v in db_versions)
+            next_unprocess = min(
+                MarabuntaVersion(v.number) for v in unprocessed
+            )
             if installed > next_unprocess:
                 raise MigrationError(
                     u'The version you are trying to install ({}) is below '

--- a/marabunta/version.py
+++ b/marabunta/version.py
@@ -10,7 +10,8 @@ FIRST_VERSION = 'setup'
 
 
 class MarabuntaVersion(Version):
-    """Version numbering for anal retentives and software idealists.
+
+    """Version numbering for Camptocamp software idealists.
     Implements the Camptocamp interface for version number classes as
     described above. A version number consists of three or five
     dot-separated numeric components, without any options.

--- a/marabunta/version.py
+++ b/marabunta/version.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import re
+from distutils.version import Version
+
+
+FIRST_VERSION = 'setup'
+
+
+class MarabuntaVersion(Version):
+    """Version numbering for anal retentives and software idealists.
+    Implements the Camptocamp interface for version number classes as
+    described above. A version number consists of three or five
+    dot-separated numeric components, without any options.
+
+    The following are valid version numbers (shown in the order that
+    would be obtained by sorting according to the supplied cmp function):
+
+        0.4.0       0.0.0.4.0  (these two are equivalent)
+        0.4.1       0.0.0.4.1  (these two are equivalent)
+        9.9.6       9.0.0.9.6  (these two are equivalent)
+        10.0.4
+        9.0.1.2.3
+        10.0.0.1.2
+        11.1.2.3.4
+
+    The following are examples of invalid version numbers:
+
+        1
+        0.4
+        0.5a1
+        0.5b3
+        2.7.2.2
+        1.3.a4
+        1.3pl1
+        1.3c4
+        11.0.1.2.3a1
+
+    """
+
+    version_re = re.compile(
+        r'^(\d+)\.(\d+)\.(\d+)(\.(\d+)\.(\d+))?$|^' + FIRST_VERSION + '$',
+        re.VERBOSE
+    )
+
+    def parse(self, version_str):
+        match = self.version_re.match(version_str)
+        if not match:
+            raise ValueError("invalid version number '%s'" % version_str)
+
+        if match.string == FIRST_VERSION:
+            self.version = match.string
+        else:
+            (major, minor, patch, revision, build) = \
+                match.group(1, 2, 3, 5, 6)
+
+            if build:
+                self.version = tuple(map(int, [
+                    major, minor, patch, revision, build
+                ]))
+            else:
+                self.version = tuple(map(int, [
+                    major, 0, 0, minor, patch
+                ]))
+
+    def __str__(self):
+
+        if self.version == FIRST_VERSION:
+            return self.version
+
+        version_str = '.'.join(map(str, self.version))
+
+        return version_str
+
+    def __cmp__(self, other):
+        return self._cmp(other)
+
+    def _cmp(self, other):
+        if isinstance(other, str):
+            other = MarabuntaVersion(other)
+
+        if self.version != other.version:
+            if self.version == FIRST_VERSION:
+                return -1
+            if other.version == FIRST_VERSION:
+                return 1
+            if self.version < other.version:
+                return -1
+            else:
+                return 1
+        return 0

--- a/tests/examples/migration_no_setup.yml
+++ b/tests/examples/migration_no_setup.yml
@@ -4,7 +4,7 @@ migration:
     install_command: odoo
     install_args: --log-level=debug
   versions:
-    - version: setup
+    - version: 0.0.1
       operations:
         pre:  # executed before 'addons'
           - echo 'pre-operation'

--- a/tests/test_migration_file.py
+++ b/tests/test_migration_file.py
@@ -35,16 +35,16 @@ def test_example_file_output(runner_gen, request, capfd):
     runner = runner_gen('migration.yml')
     runner.perform()
     expected = (
-        u'|> migration: processing version 0.0.1\n'
-        u'|> version 0.0.1: start\n'
-        u'|> version 0.0.1: execute base pre-operations\n'
-        u'|> version 0.0.1: echo pre-operation\n'
+        u'|> migration: processing version setup\n'
+        u'|> version setup: start\n'
+        u'|> version setup: execute base pre-operations\n'
+        u'|> version setup: echo pre-operation\n'
         u'pre-operation\r\n'
-        u'|> version 0.0.1: installation / upgrade of addons\n'
-        u'|> version 0.0.1: execute base post-operations\n'
-        u'|> version 0.0.1: echo post-operation\n'
+        u'|> version setup: installation / upgrade of addons\n'
+        u'|> version setup: execute base post-operations\n'
+        u'|> version setup: echo post-operation\n'
         u'post-operation\r\n'
-        u'|> version 0.0.1: done\n'
+        u'|> version setup: done\n'
         u'|> migration: processing version 0.0.2\n'
         u'|> version 0.0.2: start\n'
         u'|> version 0.0.2: version 0.0.2 is a noop\n'
@@ -67,28 +67,28 @@ def test_example_file_output(runner_gen, request, capfd):
         u'|> version 0.0.4: done\n',
         u''
     )
-    assert capfd.readouterr() == expected
+    assert expected == capfd.readouterr()
 
 
 def test_example_file_output_mode(runner_gen, request, capfd):
     runner = runner_gen('migration.yml', mode='prod')
     runner.perform()
     expected = (
-        u'|> migration: processing version 0.0.1\n'
-        u'|> version 0.0.1: start\n'
-        u'|> version 0.0.1: execute base pre-operations\n'
-        u'|> version 0.0.1: echo pre-operation\n'
+        u'|> migration: processing version setup\n'
+        u'|> version setup: start\n'
+        u'|> version setup: execute base pre-operations\n'
+        u'|> version setup: echo pre-operation\n'
         u'pre-operation\r\n'
-        u'|> version 0.0.1: execute prod pre-operations\n'
-        u'|> version 0.0.1: echo pre-operation executed only'
+        u'|> version setup: execute prod pre-operations\n'
+        u'|> version setup: echo pre-operation executed only'
         u' when the mode is prod\n'
         u'pre-operation executed only when the mode is prod\r\n'
-        u'|> version 0.0.1: installation / upgrade of addons\n'
-        u'|> version 0.0.1: execute base post-operations\n'
-        u'|> version 0.0.1: echo post-operation\n'
+        u'|> version setup: installation / upgrade of addons\n'
+        u'|> version setup: execute base post-operations\n'
+        u'|> version setup: echo post-operation\n'
         u'post-operation\r\n'
-        u'|> version 0.0.1: execute prod post-operations\n'
-        u'|> version 0.0.1: done\n'
+        u'|> version setup: execute prod post-operations\n'
+        u'|> version setup: done\n'
         u'|> migration: processing version 0.0.2\n'
         u'|> version 0.0.2: start\n'
         u'|> version 0.0.2: version 0.0.2 is a noop\n'
@@ -113,4 +113,99 @@ def test_example_file_output_mode(runner_gen, request, capfd):
         u'|> version 0.0.4: done\n',
         u''
     )
-    assert capfd.readouterr() == expected
+    assert expected == capfd.readouterr()
+
+
+def test_example_no_setup_file_output(runner_gen, request, capfd):
+    with pytest.warns(FutureWarning) as record:
+        runner = runner_gen('migration_no_setup.yml')
+        runner.perform()
+        expected = (
+            u'|> migration: processing version 0.0.1\n'
+            u'|> version 0.0.1: start\n'
+            u'|> version 0.0.1: execute base pre-operations\n'
+            u'|> version 0.0.1: echo pre-operation\n'
+            u'pre-operation\r\n'
+            u'|> version 0.0.1: installation / upgrade of addons\n'
+            u'|> version 0.0.1: execute base post-operations\n'
+            u'|> version 0.0.1: echo post-operation\n'
+            u'post-operation\r\n'
+            u'|> version 0.0.1: done\n'
+            u'|> migration: processing version 0.0.2\n'
+            u'|> version 0.0.2: start\n'
+            u'|> version 0.0.2: version 0.0.2 is a noop\n'
+            u'|> version 0.0.2: done\n'
+            u'|> migration: processing version 0.0.3\n'
+            u'|> version 0.0.3: start\n'
+            u'|> version 0.0.3: execute base pre-operations\n'
+            u'|> version 0.0.3: echo foobar\n'
+            u'foobar\r\n'
+            u'|> version 0.0.3: echo foobarbaz\n'
+            u'foobarbaz\r\n'
+            u'|> version 0.0.3: installation / upgrade of addons\n'
+            u'|> version 0.0.3: execute base post-operations\n'
+            u'|> version 0.0.3: echo post-op with unicode é â\n'
+            u'post-op with unicode é â\r\n'
+            u'|> version 0.0.3: done\n'
+            u'|> migration: processing version 0.0.4\n'
+            u'|> version 0.0.4: start\n'
+            u'|> version 0.0.4: version 0.0.4 is a noop\n'
+            u'|> version 0.0.4: done\n',
+            u''
+        )
+        assert expected == capfd.readouterr()
+
+    assert 1 == len(record)
+    warnings_msg = u'First version should be named `setup`'
+    assert warnings_msg == record[0].message.args[0]
+
+
+def test_example_no_setup_file_output_mode(runner_gen, request, capfd):
+    with pytest.warns(FutureWarning) as record:
+        runner = runner_gen('migration_no_setup.yml', mode='prod')
+        runner.perform()
+        expected = (
+            u'|> migration: processing version 0.0.1\n'
+            u'|> version 0.0.1: start\n'
+            u'|> version 0.0.1: execute base pre-operations\n'
+            u'|> version 0.0.1: echo pre-operation\n'
+            u'pre-operation\r\n'
+            u'|> version 0.0.1: execute prod pre-operations\n'
+            u'|> version 0.0.1: echo pre-operation executed only'
+            u' when the mode is prod\n'
+            u'pre-operation executed only when the mode is prod\r\n'
+            u'|> version 0.0.1: installation / upgrade of addons\n'
+            u'|> version 0.0.1: execute base post-operations\n'
+            u'|> version 0.0.1: echo post-operation\n'
+            u'post-operation\r\n'
+            u'|> version 0.0.1: execute prod post-operations\n'
+            u'|> version 0.0.1: done\n'
+            u'|> migration: processing version 0.0.2\n'
+            u'|> version 0.0.2: start\n'
+            u'|> version 0.0.2: version 0.0.2 is a noop\n'
+            u'|> version 0.0.2: done\n'
+            u'|> migration: processing version 0.0.3\n'
+            u'|> version 0.0.3: start\n'
+            u'|> version 0.0.3: execute base pre-operations\n'
+            u'|> version 0.0.3: echo foobar\n'
+            u'foobar\r\n'
+            u'|> version 0.0.3: echo foobarbaz\n'
+            u'foobarbaz\r\n'
+            u'|> version 0.0.3: execute prod pre-operations\n'
+            u'|> version 0.0.3: installation / upgrade of addons\n'
+            u'|> version 0.0.3: execute base post-operations\n'
+            u'|> version 0.0.3: echo post-op with unicode é â\n'
+            u'post-op with unicode é â\r\n'
+            u'|> version 0.0.3: execute prod post-operations\n'
+            u'|> version 0.0.3: done\n'
+            u'|> migration: processing version 0.0.4\n'
+            u'|> version 0.0.4: start\n'
+            u'|> version 0.0.4: version 0.0.4 is a noop\n'
+            u'|> version 0.0.4: done\n',
+            u''
+        )
+        assert expected == capfd.readouterr()
+
+    assert 1 == len(record)
+    warnings_msg = u'First version should be named `setup`'
+    assert warnings_msg == record[0].message.args[0]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from marabunta.version import MarabuntaVersion
+
+
+def test_marabuntaversion():
+    versions = (
+        ('1.5.1', '1.5.2b2', ValueError),
+        ('161', '3.10a', ValueError),
+        ('8.02', '8.02', ValueError),
+        ('3.4j', '1996.07.12', ValueError),
+        ('3.2.pl0', '3.1.1.6', ValueError),
+        ('2g6', '11g', ValueError),
+        ('0.9', '2.2', ValueError),
+        ('1.2.1', '1.2', ValueError),
+        ('1.1', '1.2.2', ValueError),
+        ('1.2', '1.1', ValueError),
+        ('1.2.1', '1.2.2', -1),
+        ('1.2.2', '1.2', ValueError),
+        ('1.2', '1.2.2', ValueError),
+        ('0.4.0', '0.4', ValueError),
+        ('1.13++', '5.5.kw', ValueError),
+
+        ('0.4.0', '0.4.0', 0),
+        ('0.4.0', '0.4.1', -1),
+        ('0.4.1', '0.4.0', 1),
+        ('0.4.0', '0.0.0.4.0', 0),
+        ('9.9.6', '9.0.0.9.6', 0),
+        ('9.0.1.2.3', '9.0.1.2.3', 0),
+        ('9.0.1.2.3', '10.0.0.1.2', -1),
+        ('10.0.1.2.3', '10.0.3.1.2', -1),
+        ('10.0.0.1.0', '10.0.0.1.2', -1),
+        ('11.0.0.0.1', '11.0.0.1.0', -1),
+        ('9.0.1.2.3', '9.0.1.2.2', 1),
+        ('10.0.3.1.2', '10.0.1.2.3', 1),
+        ('10.0.0.1.2', '10.0.0.1.0', 1),
+        ('11.0.0.1.0', '11.0.0.0.1', 1),
+
+        ('setup', 'setup', 0),
+        ('0.0.0', 'setup', 1),
+        ('setup', '0.0.0', -1),
+        ('0.0.0.0.0', 'setup', 1),
+        ('setup', '0.0.0.0.0', -1),
+        ('1.2.3', 'setup', 1),
+        ('setup', '4.5.6', -1),
+        ('11.0.1.0.0', 'setup', 1),
+        ('setup', '10.0.0.0.1', -1),
+    )
+
+    for v1, v2, expected in versions:
+        try:
+            actual = MarabuntaVersion(v1)._cmp(MarabuntaVersion(v2))
+        except ValueError:
+            if expected is ValueError:
+                continue
+            else:
+                raise AssertionError(("cmp(%s, %s) "
+                                      "shouldn't raise ValueError")
+                                     % (v1, v2))
+        assert expected == actual


### PR DESCRIPTION
Change the first version name from `x.y.z` to `setup`
Change versioning system from `distutils.StrictVersion` to Marabunta `MarabuntaVersion`
use only 3 and 5 digits version numbers (ex.:10.0.1 or 10.0.1.0.1)