### PR TITLE
Add variable placeholders in backup command

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,9 @@ Unreleased
 
 * Backup command and backup's ignore_if are now run with 'sh' so we can inject
   environment variables in the commands
+* Backup command can now use ``$database``, ``$db_host``, ``$db_port``,
+  ``$db_user``, ``$db_password`` that will be substituted by the current
+  configuration values
 
 **Bugfixes**
 

--- a/marabunta/parser.py
+++ b/marabunta/parser.py
@@ -18,6 +18,7 @@ from .model import (
 )
 from .version import FIRST_VERSION
 
+
 YAML_EXAMPLE = u"""
 migration:
   options:
@@ -25,7 +26,7 @@ migration:
     install_command: odoo
     install_args: --log-level=debug
     backup:
-      command: echo "backup command on ${DB_NAME}"
+      command: echo "backup command on $database $db_user $db_password $db_host $db_port"
       stop_on_failure: true
       ignore_if: test "${RUNNING_ENV}" != "prod"
   versions:
@@ -74,7 +75,7 @@ migration:
         upgrade:
           - popeye
 
-"""
+"""  # noqa
 
 
 class YamlParser(object):

--- a/marabunta/runner.py
+++ b/marabunta/runner.py
@@ -83,8 +83,12 @@ class Runner(object):
                         next_unprocess, installed
                     )
                 )
+
         if any(map(lambda x: x.backup, self.migration.versions)):
-            self.migration.options.backup.command.execute(self.log)
+            backup = self.migration.options.backup
+            backup_operation = backup.command_operation(self.config)
+            backup_operation.execute(self.log)
+
         for version in self.migration.versions:
             # when we force-execute one version, we skip all the others
             if self.config.force_version:


### PR DESCRIPTION
The backup command can now use the database configuration options, example:

     backup:
      command: echo "backup command on $database $db_user $db_password $db_host $db_port"
      stop_on_failure: true
      ignore_if: test "${RUNNING_ENV}" != "prod"