### PR TITLE
Fix lock issue with concurrent runs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,11 @@ Unreleased
 
 **Bugfixes**
 
+* When starting 2 concurrent marabunta process and the first fail, it releases
+  the lock and the second would start odoo without actually run the migration.
+  Now, when the migration lock is released, the other process(es) will recheck
+  all versions as well before running odoo.
+
 **Improvements**
 
 **Documentation**

--- a/marabunta/core.py
+++ b/marabunta/core.py
@@ -121,15 +121,15 @@ def migrate(config):
         else:
             if application_lock.replica:
                 # when a replica could finally acquire a lock, it
-                # means that the main process has finished the
-                # migration. In that case, the replica should just
-                # exit because the migration already took place. We
-                # wait till then to be sure we won't run Odoo before
-                # the main process could finish the migration.
+                # means that the concurrent process has finished the
+                # migration or that it failed to run it.
+                # In both cases after the lock is released, this process will
+                # verify if it has still to do something (if the other process
+                # failed mainly).
                 application_lock.stop = True
                 application_lock.join()
-                return
-            # we are not in the replica: go on for the migration
+            # we are not in the replica or the lock is released: go on for the
+            # migration
 
         try:
             table = MigrationTable(database)


### PR DESCRIPTION
Before: start 2 marabunta, first tries to migrate/backup and fails, the
second marabunta starts odoo without running any migration
After: start 2 marabunta: first tries to migrate/backup and fails, the
second marabunta tries to migrate / backup (and may fail as well)