### PR TITLE
Improve test cov for switch from 3 digits to 5

### DIFF
--- a/tests/examples/migration_mixed_digits2.yml
+++ b/tests/examples/migration_mixed_digits2.yml
@@ -5,13 +5,9 @@ migration:
     install_args: --log-level=debug
   versions:
     - version: setup
-    - version: 11.0.2
-    - version: 11.1.0
-    - version: 11.1.5
-    - version: 11.2.0
-    - version: 11.3.0
+    - version: 10.17.0
+    - version: 10.17.1
     # here we switch to new versioning
-    - version: 11.0.0.3.1
-    - version: 11.0.0.3.2
-    - version: 11.0.1.0.0
-    - version: 11.0.2.0.0
+    - version: 10.0.0.18.0
+    - version: 10.0.0.19.0
+

--- a/tests/test_migration_file.py
+++ b/tests/test_migration_file.py
@@ -238,10 +238,55 @@ def test_mixed_digits_output_mode(runner_gen, request, capfd):
         u'|> version 11.2.0: version 11.2.0 is already installed',
         u'|> migration: processing version 11.3.0',
         u'|> version 11.3.0: version 11.3.0 is already installed',
-        u'|> migration: processing version 11.0.3.0.1',
-        u'|> version 11.0.3.0.1: start',
-        u'|> version 11.0.3.0.1: version 11.0.3.0.1 is a noop',
-        u'|> version 11.0.3.0.1: done',
+        u'|> migration: processing version 11.0.0.3.1',
+        u'|> version 11.0.0.3.1: start',
+        u'|> version 11.0.0.3.1: version 11.0.0.3.1 is a noop',
+        u'|> version 11.0.0.3.1: done',
+        u'|> migration: processing version 11.0.0.3.2',
+        u'|> version 11.0.0.3.2: start',
+        u'|> version 11.0.0.3.2: version 11.0.0.3.2 is a noop',
+        u'|> version 11.0.0.3.2: done',
+        u'|> migration: processing version 11.0.1.0.0',
+        u'|> version 11.0.1.0.0: start',
+        u'|> version 11.0.1.0.0: version 11.0.1.0.0 is a noop',
+        u'|> version 11.0.1.0.0: done',
+        u'|> migration: processing version 11.0.2.0.0',
+        u'|> version 11.0.2.0.0: start',
+        u'|> version 11.0.2.0.0: version 11.0.2.0.0 is a noop',
+        u'|> version 11.0.2.0.0: done',
+    )
+    output = capfd.readouterr()  # ease debug
+    assert expected == tuple(output.out.splitlines())
+
+
+def test_mixed_digits_output_mode2(runner_gen, request, capfd):
+    # migrate 1st one 3 digit version then a 5 digit one
+    old_versions = [
+        # 'number date_start date_done log addons'
+        VersionRecord('10.17.0', '2018-09-06', '2018-09-06', '', ''),
+    ]
+    runner = runner_gen(
+        'migration_mixed_digits2.yml', mode='prod', db_versions=old_versions)
+    runner.perform()
+    expected = (
+        u'|> migration: processing version setup',
+        u'|> version setup: start',
+        u'|> version setup: version setup is a noop',
+        u'|> version setup: done',
+        u'|> migration: processing version 10.17.0',
+        u'|> version 10.17.0: version 10.17.0 is already installed',
+        u'|> migration: processing version 10.17.1',
+        u'|> version 10.17.1: start',
+        u'|> version 10.17.1: version 10.17.1 is a noop',
+        u'|> version 10.17.1: done',
+        u'|> migration: processing version 10.0.0.18.0',
+        u'|> version 10.0.0.18.0: start',
+        u'|> version 10.0.0.18.0: version 10.0.0.18.0 is a noop',
+        u'|> version 10.0.0.18.0: done',
+        u'|> migration: processing version 10.0.0.19.0',
+        u'|> version 10.0.0.19.0: start',
+        u'|> version 10.0.0.19.0: version 10.0.0.19.0 is a noop',
+        u'|> version 10.0.0.19.0: done',
     )
     output = capfd.readouterr()  # ease debug
     assert expected == tuple(output.out.splitlines())


### PR DESCRIPTION
Former tests were simulating a switch to major version, like

11.3.0 -> 11.0.3.0.1

Now we test a minor switch too

11.3.0 -> 11.0.0.3.1

Also, we test a mixed case w/
an upgrade to 3 digits + 5 digits right after.

/cc @yvaucher 