### PR TITLE
Fix bouncing text in maintenance page

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ Unreleased
 
 **Improvements**
 
+* Prevent text from bouncing in maintenance page
+
 **Documentation**
 
 **Build**

--- a/marabunta/html/migration.html
+++ b/marabunta/html/migration.html
@@ -45,6 +45,9 @@
       font-size: 21px;
       line-height: 1.4;
     }
+    .loader-container {
+      height: 6em;
+    }
 
     /* loader from https://projects.lukehaas.me/css-loaders/ */
     .loader,
@@ -110,7 +113,9 @@
 </head>
 <body>
   <div class="cover">
-    <div class="loader">Waiting...</div>
+    <div class="loader-container">
+      <div class="loader">Waiting...</div>
+    </div>
     <h1>odoo maintenance</h1>
     <p class="message">An upgrade of the application is currently in progress... please come back later.</p>
   </div>


### PR DESCRIPTION
### Before
![maintenance_before](https://user-images.githubusercontent.com/35060345/58029864-c328a680-7b1d-11e9-9f54-404b2c40804a.gif)

### After
![maintenance_after](https://user-images.githubusercontent.com/35060345/58029873-c7ed5a80-7b1d-11e9-8603-1b8092b36496.gif)