### PR TITLE
[IMP] web server returns status 503 instead of 200

### DIFF
--- a/marabunta/config.py
+++ b/marabunta/config.py
@@ -20,6 +20,8 @@ class Config(object):
                  force_version=None,
                  web_host='localhost',
                  web_port=8069,
+                 web_resp_status=503,
+                 web_resp_retry_after=300,  # 5 minutes
                  web_custom_html=None):
         self.migration_file = migration_file
         self.database = database
@@ -34,6 +36,8 @@ class Config(object):
             self.allow_serie = True
         self.web_host = web_host
         self.web_port = web_port
+        self.web_resp_status = web_resp_status
+        self.web_resp_retry_after = web_resp_retry_after
         self.web_custom_html = web_custom_html
 
     @classmethod
@@ -56,6 +60,8 @@ class Config(object):
                    force_version=args.force_version,
                    web_host=args.web_host,
                    web_port=args.web_port,
+                   web_resp_status=args.web_resp_status,
+                   web_resp_retry_after=args.web_resp_retry_after,
                    web_custom_html=args.web_custom_html,
                    )
 
@@ -152,6 +158,21 @@ def get_args_parser():
                        required=False,
                        default=os.environ.get('MARABUNTA_WEB_PORT', 8069),
                        help='Port for the web server')
+    group.add_argument('--web-resp-status',
+                       required=False,
+                       default=os.environ.get(
+                           'MARABUNTA_WEB_RESP_STATUS', 503
+                        ),
+                       help='Response HTTP status code of the web server')
+    group.add_argument('--web-resp-retry-after',
+                       required=False,
+                       default=os.environ.get(
+                           'MARABUNTA_WEB_RESP_RETRY_AFTER', 300
+                       ),
+                       help=(
+                            '"Retry-After" header value (in seconds) of '
+                            'response delivered by the web server')
+                       )
     group.add_argument('--web-custom-html',
                        required=False,
                        default=os.environ.get(

--- a/marabunta/config.py
+++ b/marabunta/config.py
@@ -22,7 +22,8 @@ class Config(object):
                  web_port=8069,
                  web_resp_status=503,
                  web_resp_retry_after=300,  # 5 minutes
-                 web_custom_html=None):
+                 web_custom_html=None,
+                 web_healthcheck_path=None):
         self.migration_file = migration_file
         self.database = database
         self.db_user = db_user
@@ -39,6 +40,7 @@ class Config(object):
         self.web_resp_status = web_resp_status
         self.web_resp_retry_after = web_resp_retry_after
         self.web_custom_html = web_custom_html
+        self.web_healthcheck_path = web_healthcheck_path
 
     @classmethod
     def from_parse_args(cls, args):
@@ -63,6 +65,7 @@ class Config(object):
                    web_resp_status=args.web_resp_status,
                    web_resp_retry_after=args.web_resp_retry_after,
                    web_custom_html=args.web_custom_html,
+                   web_healthcheck_path=args.web_healthcheck_path,
                    )
 
 
@@ -179,4 +182,14 @@ def get_args_parser():
                            'MARABUNTA_WEB_CUSTOM_HTML'
                        ),
                        help='Path to a custom html file to publish')
+    group.add_argument('--web-healthcheck-path',
+                       required=False,
+                       default=os.environ.get(
+                           'MARABUNTA_WEB_HEALTHCHECK_PATH'
+                       ),
+                       help=(
+                           'URL Path used for health checks HTTP requests. '
+                           'Such monitoring requests will return HTTP 200 '
+                           'status code instead of the default 503.'
+                       ))
     return parser

--- a/marabunta/core.py
+++ b/marabunta/core.py
@@ -109,7 +109,8 @@ def migrate(config):
     webapp = WebApp(config.web_host, config.web_port,
                     custom_maintenance_file=config.web_custom_html,
                     resp_status=config.web_resp_status,
-                    resp_retry_after=config.web_resp_retry_after)
+                    resp_retry_after=config.web_resp_retry_after,
+                    healthcheck_path=config.web_healthcheck_path)
 
     webserver = WebServer(webapp)
     webserver.daemon = True

--- a/marabunta/core.py
+++ b/marabunta/core.py
@@ -107,7 +107,9 @@ def migrate(config):
     :type config: Config
     """
     webapp = WebApp(config.web_host, config.web_port,
-                    custom_maintenance_file=config.web_custom_html)
+                    custom_maintenance_file=config.web_custom_html,
+                    resp_status=config.web_resp_status,
+                    resp_retry_after=config.web_resp_retry_after)
 
     webserver = WebServer(webapp)
     webserver.daemon = True


### PR DESCRIPTION
Currently while upgrading the Marabunta web server is returning a maintenance page with a HTTP 200 status code. This could lead to issues especially if third services are sending HTTP requests to Odoo, they'll get an HTTP 200 as an answer meaning the request has been well processed, which of course is wrong.
To fix this situation I propose to use the HTTP 503 status code (Service Unavailable) + a `Retry-After` header set by default to 5 minutes.

Both status code and Retry-After value can be changed through the parameters / environment variables.

This PR aims to replace https://github.com/camptocamp/marabunta/pull/51