### PR TITLE
Binary wheel for psycopg2 dependency

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ Unreleased
 
 **Improvements**
 
+* Switch to Psycopg2 binary wheel
+
 **Documentation**
 
 **Build**

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='AGPLv3+',
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
-        "psycopg2",
+        "psycopg2-binary",
         "ruamel.yaml>=0.15.1",
         "pexpect",
         "werkzeug",


### PR DESCRIPTION
Easier to install, and avoid building dependency each time.