### PR TITLE
[FIX] Drop support for python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,lint
+envlist = py38,py39,py310,py311,lint
 
 [testenv]
 extras = test


### PR DESCRIPTION
The build is failing with:
```
Run actions/setup-python@v4
Installed versions
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
```
